### PR TITLE
fix(manifest): replace _execute_action with _execute_browser_action for MV2

### DIFF
--- a/src/v2-manifest.json
+++ b/src/v2-manifest.json
@@ -22,7 +22,7 @@
     "default_popup": "public/index.html"
   },
   "commands": {
-    "_execute_action": {
+    "_execute_browser_action": {
       "suggested_key": {
         "default": "Ctrl+U",
         "mac": "Command+U"


### PR DESCRIPTION
Link Roamer is submitted to [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/link-roamer/) as a Manifest V2 extension, but the manifest incorrectly uses `_execute_action` (a [Manifest V3-only](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#special_shortcuts) command).

As a result, the shortcut fails to register in Firefox, since MV2 requires `_execute_browser_action` instead.

![图片](https://github.com/user-attachments/assets/a15648a8-7220-4a03-b049-4d600a06b59d)
